### PR TITLE
CFE-2546: Implement import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ make install
 ## Using the provider
 
 See the [example](./examples/main.tf) directory for an example usage.
+
+## Importing DNS record
+
+To import a DNS record from GoDaddy, the ID should conform to the following syntax:
+
+`<domain>:<name>:<type>`
+
+Example
+
+```terraform
+terraform import domains_record.test_record test-domain.com:terraform:CNAME
+```

--- a/domains/resource_record.go
+++ b/domains/resource_record.go
@@ -2,42 +2,82 @@ package domains
 
 import (
 	"context"
+	"errors"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	openapiclient "github.com/sigmadigitalza/godaddy-domains-client"
+	"strings"
 )
+
+var (
+	InvalidRecordIdError = errors.New("invalid record ID specified")
+)
+
+func importStateRecordContext(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+	id := d.Id()
+
+	if strings.Contains(id, ":") {
+		values := strings.Split(id, ":")
+
+		if len(values) != 3 {
+			return nil, InvalidRecordIdError
+		}
+
+		err := d.Set("domain", values[0])
+		if err != nil {
+			return nil, err
+		}
+
+		err = d.Set("name", values[1])
+		if err != nil {
+			return nil, err
+		}
+
+		err = d.Set("type", values[2])
+		if err != nil {
+			return nil, err
+		}
+
+		d.SetId(id)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}
 
 func resourceRecord() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceRecordCreate,
-		ReadContext: resourceRecordRead,
+		ReadContext:   resourceRecordRead,
 		UpdateContext: resourceRecordUpdate,
 		DeleteContext: resourceRecordDelete,
 		Schema: map[string]*schema.Schema{
 			"domain": &schema.Schema{
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"data": &schema.Schema{
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 			},
 			"name": &schema.Schema{
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"type": &schema.Schema{
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 			"ttl": &schema.Schema{
-				Type: schema.TypeInt,
+				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
+		},
+		Importer: &schema.ResourceImporter{
+			StateContext: importStateRecordContext,
 		},
 	}
 }
@@ -71,13 +111,13 @@ func resourceRecordCreate(ctx context.Context, d *schema.ResourceData, m interfa
 func resourceRecordRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*openapiclient.APIClient)
 
-	domainName := d.Get("domain").(string)
 	name := d.Get("name").(string)
+	domain := d.Get("domain").(string)
 	recordType := d.Get("type").(string)
 
 	var diags diag.Diagnostics
 
-	dnsRecords, resp, err := client.V1Api.RecordGet(ctx, domainName, recordType, name).Execute()
+	dnsRecords, resp, err := client.V1Api.RecordGet(ctx, domain, recordType, name).Execute()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     godaddy-domains = {
       version = "1.0.0",
-      source = "sigmadigitalza/godaddy-domains"
+      source = "sigmadigital.io/godaddy/domains"
     }
   }
 }
@@ -19,7 +19,7 @@ data "domains_domain" "test_domain" {
   domain = "test-domain.com"
 }
 
-resource "domains_record" "terraform_record" {
+resource "domains_record" "test_record" {
   provider = "godaddy-domains"
 
   domain = data.domains_domain.test_domain.domain


### PR DESCRIPTION
## Scope

To import legacy tenants into Terraform managed infrastructure, an import function is required.

## Work Done

1. Created import function.
2. Registered import function.
3. Updated documentation.

## Notes

Tested locally and resource was successfully imported and the state file reflected the appropriate values.

-----
[View rendered README.md](https://github.com/sigmadigitalza/terraform-provider-godaddy-domains/blob/feat/CFE-2546/domains/README.md)